### PR TITLE
Synchronize validation method using another thread pool

### DIFF
--- a/imoji-android-sdk/src/main/java/io/imoji/sdk/ApiTask.java
+++ b/imoji-android-sdk/src/main/java/io/imoji/sdk/ApiTask.java
@@ -69,6 +69,14 @@ public class ApiTask<V> {
             new LinkedBlockingQueue<Runnable>()
     );
 
+    public static final ExecutorService THREAD_POOL_EXECUTOR_VALIDATE = new ThreadPoolExecutor(
+            1,
+            1,
+            THREAD_POOL_KEEP_ALIVE_TIME,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<Runnable>()
+    );
+
     private static final int WRAPPED_ASYNC_ERROR_MESSAGE = 1;
 
     /**
@@ -83,7 +91,7 @@ public class ApiTask<V> {
         protected final V doInBackground(Future<V>... params) {
             try {
                 FutureTask<V> task = (FutureTask<V>) params[0];
-                THREAD_POOL_EXECUTOR_SERVICE.submit(task);
+                task.run();
                 return task.get();
             } catch (ExecutionException e) {
                 Log.e(ApiTask.class.getName(), "Unable to perform async task, cancelling…", e);
@@ -112,7 +120,6 @@ public class ApiTask<V> {
          */
         @SuppressWarnings("UnusedParameters")
         protected void onError(@NonNull Throwable error) {
-
         }
     }
 
@@ -184,7 +191,8 @@ public class ApiTask<V> {
      * @see ExecutorService
      */
     public V executeImmediately() throws ExecutionException, InterruptedException {
-        return this.executeImmediately(THREAD_POOL_EXECUTOR_SERVICE);
+        scheduledTask.run();
+        return scheduledTask.get();
     }
 
     /**

--- a/imoji-android-sdk/src/main/java/io/imoji/sdk/internal/NetworkSession.java
+++ b/imoji-android-sdk/src/main/java/io/imoji/sdk/internal/NetworkSession.java
@@ -376,7 +376,7 @@ public abstract class NetworkSession implements Session {
             public T call() throws Exception {
                 OAuthTokenResponse oAuthTokenResponse;
                 try {
-                    oAuthTokenResponse = validateSession().executeImmediately();
+                    oAuthTokenResponse = validateSession().executeImmediately(ApiTask.THREAD_POOL_EXECUTOR_VALIDATE);
                     Map<String, String> headersWithOauth = new HashMap<>(headers);
                     Map<String, String> queryStringsWithOauth = new HashMap<>(queryStrings);
 
@@ -395,7 +395,7 @@ public abstract class NetworkSession implements Session {
                         // generate a new token and call the same method again
                         if (errorResponse != null && ImojiSDKConstants.Errors.OAUTH_VERIFICATION_ERROR_STATUS.equals(errorResponse.getServerStatus())) {
                             clearOauthSettings();
-                            oAuthTokenResponse = validateSession().executeImmediately();
+                            oAuthTokenResponse = validateSession().executeImmediately(ApiTask.THREAD_POOL_EXECUTOR_VALIDATE);
 
                             if (oAuthTokenResponse != null) {
                                 return oauthValidatedQueryStringConnection(
@@ -421,7 +421,7 @@ public abstract class NetworkSession implements Session {
             public T call() throws Exception {
                 OAuthTokenResponse oAuthTokenResponse;
                 try {
-                    oAuthTokenResponse = validateSession().executeImmediately();
+                    oAuthTokenResponse = validateSession().executeImmediately(ApiTask.THREAD_POOL_EXECUTOR_VALIDATE);
                     Map<String, String> headersWithOauth = new HashMap<>(headers);
                     Map<String, String> bodyWithOauth = new HashMap<>(body);
 
@@ -440,7 +440,7 @@ public abstract class NetworkSession implements Session {
                         // generate a new token and call the same method again
                         if (errorResponse != null && ImojiSDKConstants.Errors.OAUTH_VERIFICATION_ERROR_STATUS.equals(errorResponse.getServerStatus())) {
                             clearOauthSettings();
-                            oAuthTokenResponse = validateSession().executeImmediately();
+                            oAuthTokenResponse = validateSession().executeImmediately(ApiTask.THREAD_POOL_EXECUTOR_VALIDATE);
 
                             if (oAuthTokenResponse != null) {
                                 return oauthValidatedFormEncodedConnection(


### PR DESCRIPTION
ExecuteImmediately now runs on the same thread that it was called from instead of running the task on another executor. This endedup creating a deadlock by using  all threads of the pool